### PR TITLE
Fix global options property name mismatch

### DIFF
--- a/vsts-extension-shared/vsts-extension-shared.psm1
+++ b/vsts-extension-shared/vsts-extension-shared.psm1
@@ -10,8 +10,8 @@ function Convert-GlobalOptions
 
     $globalOptions = @{
         TfxInstall = ($parameters["TfxInstall"] -eq $true)
-        TfxInstallUpdate = ($parameters["TfxUpdate"] -eq $true)
-        TfxInstallPath = [string]$parameters["TfxInstallPath"]
+        TfxUpdate = ($parameters["TfxUpdate"] -eq $true)
+        TfxLocation = [string]$parameters["TfxLocation"]
         ServiceEndpoint = [string]$parameters["ServiceEndpoint"]
     }
 


### PR DESCRIPTION
The Convert-GlobalOptions is not returning an object with correct property names thus the TfxUpdate and TfxLocation task properties are never used.
