### PR TITLE
Unable to locate npm

### DIFF
--- a/vsts-extension-shared/vsts-extension-shared.psm1
+++ b/vsts-extension-shared/vsts-extension-shared.psm1
@@ -355,6 +355,7 @@ function Find-Tfx
 
         Write-Debug "Trying to update tfx in: $TfxLocation"
 
+        $npm = Get-Command -Name npm -ErrorAction Ignore
         if(!$npm)
         {
             throw ("Unable to locate npm")


### PR DESCRIPTION
There's no guarantee the code will have hit the below get-command prior to reaching the second attempted use of $npm.

$npm = Get-Command -Name npm -ErrorAction Ignore
