### PR TITLE
Fixing copy-paste error

### DIFF
--- a/vsts-extension-shared/vsts-extension-shared.psm1
+++ b/vsts-extension-shared/vsts-extension-shared.psm1
@@ -239,9 +239,9 @@ function Convert-PublishOptions
         BypassValidation = ($parameters["BypassValidation"] -eq $true)
     }
 
-    if ($shareOptions.VsixPath -match "[?*]")
+    if ($publishOptions.VsixPath -match "[?*]")
     {
-        $shareOptions.VsixPath = [string](Find-Files $shareOptions.VsixPath)
+        $publishOptions.VsixPath = [string](Find-Files $publishOptions.VsixPath)
     }
 
     Write-Debug "PublishOptions:"


### PR DESCRIPTION
This fixes an error where wildcards would not be expanded when doing a publish operation.
